### PR TITLE
Fix NRE and return BadRequest after deserializing empty JSON content.

### DIFF
--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -7,6 +7,7 @@ Add changes here when they're committed to the `master` branch. To publish, upda
 Prefix the description of each change with `[major]`, `[minor]`, or `[patch]` in accordance with [SemVer](http://semver.org).
 
 * [major] Upgrade to .NET Standard 2.0 and .NET 4.6.1. Upgrade NuGet dependencies.
+* [patch] Fix NRE when creating request DTOs caused by deserializing the empty string as JSON.
 
 ## Released
 

--- a/src/Facility.Core/Http/JsonHttpContentSerializer.cs
+++ b/src/Facility.Core/Http/JsonHttpContentSerializer.cs
@@ -60,7 +60,10 @@ namespace Facility.Core.Http
 			{
 				using (var stream = await content.ReadAsStreamAsync().ConfigureAwait(false))
 				using (var textReader = new StreamReader(stream))
-					return ServiceResult.Success(ServiceJsonUtility.FromJsonTextReader(textReader, dtoType));
+				{
+					var deserializedContent = ServiceJsonUtility.FromJsonTextReader(textReader, dtoType);
+					return deserializedContent != null ? ServiceResult.Success(deserializedContent) : ServiceResult.Failure(HttpServiceErrors.CreateInvalidContent("Content must not be empty."));
+				}
 			}
 			catch (JsonException exception)
 			{

--- a/tests/Facility.Core.UnitTests/Http/InvalidResponseTests.cs
+++ b/tests/Facility.Core.UnitTests/Http/InvalidResponseTests.cs
@@ -45,6 +45,14 @@ namespace Facility.Core.UnitTests.Http
 		}
 
 		[Test]
+		public async Task EmptyJson()
+		{
+			await GetApiInfoInvalidResponse(
+				_ => new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(string.Empty, Encoding.UTF8, "application/json") },
+				ServiceErrors.InvalidResponse, HttpServiceErrors.CreateInvalidContent("").Message);
+		}
+
+		[Test]
 		public async Task UnexpectedSuccess()
 		{
 			await GetApiInfoInvalidResponse(


### PR DESCRIPTION
Newtonsoft does not throw an exception when deserializing an empty
string even though it is not valid JSON (see
https://github.com/JamesNK/Newtonsoft.Json/issues/1655 for details).
Returning a failure in this situation prevents an NRE when casting
the request body in generated code.

v1 fix: https://github.com/FacilityApi/FacilityCSharp/pull/16