### PR TITLE
Fix NRE and return BadRequest after deserializing empty JSON content. (v1)

### DIFF
--- a/src/Facility.Core/Http/JsonHttpContentSerializer.cs
+++ b/src/Facility.Core/Http/JsonHttpContentSerializer.cs
@@ -65,7 +65,10 @@ namespace Facility.Core.Http
 			{
 				using (var stream = await content.ReadAsStreamAsync().ConfigureAwait(false))
 				using (var textReader = new StreamReader(stream))
-					return ServiceResult.Success(ServiceJsonUtility.FromJsonTextReader(textReader, dtoType));
+				{
+					var deserializedContent = ServiceJsonUtility.FromJsonTextReader(textReader, dtoType);
+					return deserializedContent != null ? ServiceResult.Success(deserializedContent) : ServiceResult.Failure(HttpServiceErrors.CreateInvalidContent("Content must not be empty."));
+				}
 			}
 			catch (JsonException exception)
 			{

--- a/tests/Facility.ExampleApi.UnitTests/HttpMappingTests.cs
+++ b/tests/Facility.ExampleApi.UnitTests/HttpMappingTests.cs
@@ -117,5 +117,13 @@ namespace Facility.ExampleApi.UnitTests
 			var response = await httpClient.PostAsync("http://local.example.com/v1/kitchen", new ByteArrayContent(new byte[0]));
 			response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
 		}
+
+		[Test]
+		public async Task MissingBodyWithJsonContentType_BadRequest()
+		{
+			var httpClient = TestUtility.CreateTestHttpClient();
+			var response = await httpClient.PostAsync("http://local.example.com/v1/widgets/123/edit", new StringContent(string.Empty, Encoding.UTF8, HttpServiceUtility.JsonMediaType));
+			response.StatusCode.Should().Be(HttpStatusCode.BadRequest);
+		}
 	}
 }


### PR DESCRIPTION
Newtonsoft does not throw an exception when deserializing an empty
string even though it is not valid JSON (see
https://github.com/JamesNK/Newtonsoft.Json/issues/1655 for details).
Returning a failure in this situation prevents an NRE when casting
the request body in generated code.

Related to https://github.com/FacilityApi/FacilityCSharp/pull/15