### PR TITLE
add const values for enum literals

### DIFF
--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -7,6 +7,7 @@ Add changes here when they're committed to the `master` branch. To publish, upda
 Prefix the description of each change with `[major]`, `[minor]`, or `[patch]` in accordance with [SemVer](http://semver.org).
 
 * [major] Upgrade to .NET Standard 2.0 and .NET 4.6.1. Upgrade NuGet dependencies.
+* [minor] Added strong types for fsd enum literals.
 
 ## Released
 

--- a/src/Facility.CodeGen.CSharp/CSharpGenerator.cs
+++ b/src/Facility.CodeGen.CSharp/CSharpGenerator.cs
@@ -171,7 +171,8 @@ namespace Facility.CodeGen.CSharp
 							code.WriteLineSkipOnce();
 							CSharpUtility.WriteSummary(code, enumValue.Summary);
 							CSharpUtility.WriteObsoleteAttribute(code, enumValue);
-							code.WriteLine($"public static readonly {enumName} {memberName} = new {enumName}(\"{enumValue.Name}\");");
+							code.WriteLine($"public const string {memberName}Value = \"{enumValue.Name}\";");
+							code.WriteLine($"public static readonly {enumName} {memberName} = new {enumName}({memberName}Value);");
 						}
 
 						code.WriteLine();

--- a/tests/Facility.CodeGen.CSharp.UnitTests/CSharpGeneratorTests.cs
+++ b/tests/Facility.CodeGen.CSharp.UnitTests/CSharpGeneratorTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.IO;
+using System.Linq;
 using Facility.Definition;
 using Facility.Definition.Fsd;
 using FluentAssertions;
@@ -75,6 +76,19 @@ namespace Facility.CodeGen.CSharp.UnitTests
 				StringAssert.DoesNotContain("DefinitionNamespace", file.Text);
 			}
 
+		}
+
+		[Test]
+		public void EnumValues()
+		{
+			var definition = "service TestApi { method do {}: {} enum ValueTest { item1, item2 } }";
+			var parser = new FsdParser();
+			var service = parser.ParseDefinition(new ServiceDefinitionText("TestApi.fsd", definition));
+			var generator = new CSharpGenerator { GeneratorName = nameof(CSharpGeneratorTests) };
+			var output = generator.GenerateOutput(service);
+			var enumFile = output.Files.FirstOrDefault(f => f.Name.Contains("ValueTest"));
+			StringAssert.Contains("Item1Value = \"item1\"", enumFile.Text);
+			StringAssert.Contains("Item2Value = \"item2\"", enumFile.Text);
 		}
 
 		private void ThrowsServiceDefinitionException(string definition, string message)


### PR DESCRIPTION
To write a `switch` statement for existing fsd enums, it would look like this:

```
switch (enumValue)
{
    case EnumType e when e == EnumType.Item1:
       ...
    case EnumType e when e == EnumType.Item2:
       ...
}
```

For returning an object, an alternative is to this switch is to write a long ternary statement:

```
return enumValue == EnumType.Item1 ? ... :  enumValue == EnumType.Item2 ? ... : ...
```

By adding a strongly type symbol for a const literal, we can write a clean switch statement:

```
switch (enumValue.toString())
{
    case EnumType.Item1Value:
    case EnumType.Item2Value:
}
```