### PR TITLE
Validate required query and normal parameters

### DIFF
--- a/VersionHistory.md
+++ b/VersionHistory.md
@@ -1,5 +1,8 @@
 # Version History
 
+* [major] Validate parmeters with the `[required]` attribute in generated code
+
+## Released
 ### 2.1.0
 
 * Expose `BaseUri` to derived `HttpClientService`.

--- a/src/Facility.Core/ServiceDto.cs
+++ b/src/Facility.Core/ServiceDto.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Collections.Generic;
+
 namespace Facility.Core
 {
 	/// <summary>
@@ -14,6 +17,11 @@ namespace Facility.Core
 		/// Determines if two DTOs are equivalent.
 		/// </summary>
 		public abstract bool IsEquivalentTo(ServiceDto other);
+
+		/// <summary>
+		/// Returns validation errors
+		/// </summary>
+		public virtual IEnumerable<string> GetValidationErrors() => Array.Empty<string>();
 	}
 
 	/// <summary>

--- a/tests/Facility.CodeGen.CSharp.UnitTests/CSharpGeneratorTests.cs
+++ b/tests/Facility.CodeGen.CSharp.UnitTests/CSharpGeneratorTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using Facility.Definition;
 using Facility.Definition.Fsd;
 using FluentAssertions;
@@ -62,6 +63,30 @@ namespace Facility.CodeGen.CSharp.UnitTests
 				StringAssert.DoesNotContain("DefinitionNamespace", file.Text);
 			}
 
+		}
+
+		[Test]
+		public void ValidateRequiredNormalParameter()
+		{
+			var definition = "[http(url: \"https://testapi.com\")] [csharp(namespace: Test)] service TestApi { [http(method: POST, path: \"/do\")] method do { [required]\nfield: string; }: {} }";
+			var parser = new FsdParser();
+			var service = parser.ParseDefinition(new ServiceDefinitionText("TestApi.fsd", definition));
+			var generator = new CSharpGenerator { GeneratorName = nameof(CSharpGeneratorTests), NamespaceName = "Test" };
+			var output = generator.GenerateOutput(service);
+			var file = output.Files.Single(x => x.Name == "DoRequestDto.g.cs");
+			StringAssert.Contains("if (Field == null)", file.Text);
+		}
+
+		[Test]
+		public void ValidateRequiredQueryParameter()
+		{
+			var definition = "[http(url: \"https://testapi.com\")] [csharp(namespace: Test)] service TestApi { [http(method: GET, path: \"/do\")] method do { [required]\nfield: string; }: {} }";
+			var parser = new FsdParser();
+			var service = parser.ParseDefinition(new ServiceDefinitionText("TestApi.fsd", definition));
+			var generator = new CSharpGenerator { GeneratorName = nameof(CSharpGeneratorTests), NamespaceName = "Test" };
+			var output = generator.GenerateOutput(service);
+			var file = output.Files.Single(x => x.Name == "DoRequestDto.g.cs");
+			StringAssert.Contains("if (Field == null)", file.Text);
 		}
 
 		private void ThrowsServiceDefinitionException(string definition, string message)


### PR DESCRIPTION
Addresses https://github.com/FacilityApi/FacilityCSharp/issues/23

The change validates required parameters as not being `null`. Required query and normal parameters _do not_ fail validation if they are empty strings, however, since empty strings may be perfectly valid values.