### PR TITLE
Remove unnecessary System.Net.Http package reference

### DIFF
--- a/src/Facility.Core/Facility.Core.csproj
+++ b/src/Facility.Core/Facility.Core.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <Reference Include="System.Net.Http" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
This package is not necessary when targeting netstandard2.0 or net45+ and is only compatible with Microsoft’s .NET implementation.