### PR TITLE
Make routing case insensitive when using path parameters.

### DIFF
--- a/src/Facility.Core/Http/ServiceHttpHandler.cs
+++ b/src/Facility.Core/Http/ServiceHttpHandler.cs
@@ -244,7 +244,7 @@ namespace Facility.Core.Http
 				foreach (string name in names)
 					regexPattern = regexPattern.ReplaceOrdinal("\\{" + name + "}", "(?'" + name + "'[^/]+)");
 				regexPattern = "^(?:" + regexPattern + ")$";
-				Match match = new Regex(regexPattern, RegexOptions.CultureInvariant).Match(requestPath);
+				Match match = new Regex(regexPattern, RegexOptions.CultureInvariant | RegexOptions.IgnoreCase).Match(requestPath);
 				return match.Success ? names.ToDictionary(name => name, name => Uri.UnescapeDataString(match.Groups[name].ToString())) : null;
 			}
 


### PR DESCRIPTION
We recently changed some of our routes to use camelCase instead of all lowercase and was surprised when clients that hadn't been updated with the new client started 404ing. I'm *pretty* sure this is the problem but I'd feel a lot better with a test to verify. I tried heading down that path but felt like I was adding *a lot* and didn't want to head in the wrong direction for testing so I figured I'd open this open and get a little more direction from @ejball before adding a test here.