### PR TITLE
Add implicit cast to ServiceObject.

### DIFF
--- a/src/Facility.Core/ServiceObject.cs
+++ b/src/Facility.Core/ServiceObject.cs
@@ -51,6 +51,12 @@ public sealed class ServiceObject
 		m_jsonObject is { } jsonObject ? SystemTextJsonServiceSerializer.Instance.ToJson(jsonObject) :
 		"";
 
+	[SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Create is the named alternative.")]
+	public static implicit operator ServiceObject?(JObject? jObject) => Create(jObject);
+
+	[SuppressMessage("Usage", "CA2225:Operator overloads have named alternates", Justification = "Create is the named alternative.")]
+	public static implicit operator ServiceObject?(JsonObject? jsonObject) => Create(jsonObject);
+
 	private ServiceObject(JObject jObject) => m_jObject = jObject;
 
 	private ServiceObject(JsonObject jsonObject) => m_jsonObject = jsonObject;


### PR DESCRIPTION
This makes it easier to update fsdgencsharp in code that already used JObject.

We could add implicit cast the other way for even greater source compatibility, but I'm concerned that would introduce non-obvious conversions between JObject and JsonObject.