### PR TITLE
Support async serialization/deserialization. 

### DIFF
--- a/src/Facility.Core/Http/HttpClientService.cs
+++ b/src/Facility.Core/Http/HttpClientService.cs
@@ -24,9 +24,9 @@ public abstract class HttpClientService
 		m_baseUrl = baseUri == null ? "/" : (baseUri.IsAbsoluteUri ? baseUri.AbsoluteUri : baseUri.OriginalString).TrimEnd('/') + "/";
 
 		BaseUri = baseUri;
-		ContentSerializer = (settings.ContentSerializer ?? defaults.ContentSerializer ?? HttpContentSerializer.Legacy).WithMemoryStreamCreatorIfNotNull(settings.MemoryStreamCreator);
-		BytesSerializer = (settings.BytesSerializer ?? BytesHttpContentSerializer.Instance).WithMemoryStreamCreatorIfNotNull(settings.MemoryStreamCreator);
-		TextSerializer = (settings.TextSerializer ?? TextHttpContentSerializer.Instance).WithMemoryStreamCreatorIfNotNull(settings.MemoryStreamCreator);
+		ContentSerializer = settings.ContentSerializer ?? defaults.ContentSerializer ?? HttpContentSerializer.Legacy;
+		BytesSerializer = settings.BytesSerializer ?? BytesHttpContentSerializer.Instance;
+		TextSerializer = settings.TextSerializer ?? TextHttpContentSerializer.Instance;
 	}
 
 	/// <summary>

--- a/src/Facility.Core/Http/HttpClientServiceSettings.cs
+++ b/src/Facility.Core/Http/HttpClientServiceSettings.cs
@@ -31,11 +31,6 @@ public sealed class HttpClientServiceSettings
 	public HttpContentSerializer? TextSerializer { get; set; }
 
 	/// <summary>
-	/// The memory stream creator to be used by content serializers (optional).
-	/// </summary>
-	public Func<Stream>? MemoryStreamCreator { get; set; }
-
-	/// <summary>
 	/// The aspects used when sending requests and receiving responses (optional).
 	/// </summary>
 	public IReadOnlyList<HttpClientServiceAspect>? Aspects { get; set; }

--- a/src/Facility.Core/Http/HttpContentSerializer.cs
+++ b/src/Facility.Core/Http/HttpContentSerializer.cs
@@ -8,18 +8,7 @@ public abstract class HttpContentSerializer
 	/// <summary>
 	/// Creates a standard HTTP content serializer.
 	/// </summary>
-	/// <remarks>Values are serialized and deserialized via memory streams so that the actual I/O can be asynchronous
-	/// whether or not the serialization format supports asynchronous I/O directly. This also makes it simple to calculate
-	/// the length of the content. Consider using <c>Microsoft.IO.RecyclableMemoryStream</c> to improve performance
-	/// by setting <c>memoryStreamCreator</c> to <c>RecyclableMemoryStreamManager.GetStream</c>. Otherwise
-	/// <c>System.IO.MemoryStream</c> is used.</remarks>
 	public static HttpContentSerializer Create(ServiceSerializer serviceSerializer) => new StandardHttpContentSerializer(serviceSerializer);
-
-	/// <summary>
-	/// Returns an identical HTTP content serializer that uses the specified memory stream creator as needed.
-	/// </summary>
-	public HttpContentSerializer WithMemoryStreamCreator(Func<Stream> memoryStreamCreator) =>
-		WithMemoryStreamCreatorCore(memoryStreamCreator ?? throw new ArgumentNullException(nameof(memoryStreamCreator)));
 
 	/// <summary>
 	/// The default media type for the serializer.
@@ -91,11 +80,6 @@ public abstract class HttpContentSerializer
 	/// Reads a DTO from the specified HTTP content.
 	/// </summary>
 	protected abstract Task<ServiceResult<object>> ReadHttpContentAsyncCore(Type objectType, HttpContent content, CancellationToken cancellationToken);
-
-	/// <summary>
-	/// Creates an identical HTTP content serializer that uses the specified memory stream creator as needed.
-	/// </summary>
-	protected virtual HttpContentSerializer WithMemoryStreamCreatorCore(Func<Stream> memoryStreamCreator) => this;
 
 	internal static HttpContentSerializer Legacy { get; } = Create(NewtonsoftJsonServiceSerializer.Instance);
 }

--- a/src/Facility.Core/Http/HttpServiceUtility.cs
+++ b/src/Facility.Core/Http/HttpServiceUtility.cs
@@ -76,9 +76,6 @@ public static class HttpServiceUtility
 
 	internal static bool UsesTextSerializer(Type objectType) => objectType == typeof(string);
 
-	internal static HttpContentSerializer WithMemoryStreamCreatorIfNotNull(this HttpContentSerializer contentSerializer, Func<Stream>? memoryStreamCreator) =>
-		memoryStreamCreator is null ? contentSerializer : contentSerializer.WithMemoryStreamCreator(memoryStreamCreator);
-
 	private sealed class DictionaryFromHeaders : IReadOnlyDictionary<string, string>
 	{
 		public DictionaryFromHeaders(IReadOnlyList<HttpHeaders> httpHeaders)

--- a/src/Facility.Core/Http/HttpServiceUtility.cs
+++ b/src/Facility.Core/Http/HttpServiceUtility.cs
@@ -57,7 +57,7 @@ public static class HttpServiceUtility
 	internal static int IndexOfOrdinal(this string value, char ch)
 	{
 #if NETSTANDARD2_0
-			return value.IndexOf(ch);
+		return value.IndexOf(ch);
 #else
 		return value.IndexOf(ch, StringComparison.Ordinal);
 #endif
@@ -66,7 +66,7 @@ public static class HttpServiceUtility
 	internal static string ReplaceOrdinal(this string value, string oldValue, string newValue)
 	{
 #if NETSTANDARD2_0
-			return value.Replace(oldValue, newValue);
+		return value.Replace(oldValue, newValue);
 #else
 		return value.Replace(oldValue, newValue, StringComparison.Ordinal);
 #endif

--- a/src/Facility.Core/Http/JsonHttpContentSerializer.cs
+++ b/src/Facility.Core/Http/JsonHttpContentSerializer.cs
@@ -1,3 +1,7 @@
+using System.Net;
+using System.Net.Http.Headers;
+using Newtonsoft.Json;
+
 namespace Facility.Core.Http;
 
 /// <summary>
@@ -24,9 +28,8 @@ public class JsonHttpContentSerializer : HttpContentSerializer
 	/// </summary>
 	public JsonHttpContentSerializer(JsonHttpContentSerializerSettings? settings)
 	{
-		// we always force async I/O now, so we can ignore settings.ForceAsyncIO
+		m_forceAsyncIO = settings?.ForceAsyncIO ?? false;
 		m_memoryStreamCreator = settings?.MemoryStreamCreator;
-		m_contentSerializer = Legacy.WithMemoryStreamCreatorIfNotNull(m_memoryStreamCreator);
 
 		SupportedMediaTypes = new[] { HttpServiceUtility.JsonMediaType };
 	}
@@ -54,15 +57,94 @@ public class JsonHttpContentSerializer : HttpContentSerializer
 	/// <summary>
 	/// Creates HTTP content for the specified DTO.
 	/// </summary>
-	protected override HttpContent CreateHttpContentCore(object content, string? mediaType) =>
-		m_contentSerializer.CreateHttpContent(content, mediaType ?? DefaultMediaType);
+	protected override HttpContent CreateHttpContentCore(object content, string? mediaType)
+	{
+		var memoryStream = CreateMemoryStream();
+		ServiceJsonUtility.ToJsonStream(content, memoryStream);
+		return new DelegateHttpContent(mediaType ?? DefaultMediaType, memoryStream);
+	}
 
 	/// <summary>
 	/// Reads a DTO from the specified HTTP content.
 	/// </summary>
-	protected override Task<ServiceResult<object>> ReadHttpContentAsyncCore(Type objectType, HttpContent content, CancellationToken cancellationToken) =>
-		m_contentSerializer.ReadHttpContentAsync(objectType, content, cancellationToken);
+	protected override async Task<ServiceResult<object>> ReadHttpContentAsyncCore(Type objectType, HttpContent content, CancellationToken cancellationToken)
+	{
+		try
+		{
+			if (m_forceAsyncIO)
+			{
+				// read content into memory so that ASP.NET Core doesn't complain about synchronous I/O during JSON deserialization
+				using var stream = CreateMemoryStream();
+#if NET6_0_OR_GREATER
+				await content.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
+#else
+				await content.CopyToAsync(stream).ConfigureAwait(false);
+#endif
+				stream.Seek(0, SeekOrigin.Begin);
+				return ReadJsonStream(objectType, stream);
+			}
+			else
+			{
+#if NET6_0_OR_GREATER
+				using var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+#else
+				using var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
+#endif
+				return ReadJsonStream(objectType, stream);
+			}
+		}
+		catch (JsonException exception)
+		{
+			return ServiceResult.Failure(HttpServiceErrors.CreateInvalidContent(exception.Message));
+		}
+	}
 
+	private static ServiceResult<object> ReadJsonStream(Type objectType, Stream stream)
+	{
+		using var textReader = new StreamReader(stream);
+		var deserializedContent = ServiceJsonUtility.FromJsonTextReader(textReader, objectType);
+		if (deserializedContent is null)
+			return ServiceResult.Failure(HttpServiceErrors.CreateInvalidContent("Content must not be empty."));
+		return ServiceResult.Success(deserializedContent);
+	}
+
+	private sealed class DelegateHttpContent : HttpContent
+	{
+		public DelegateHttpContent(string mediaType, Stream memoryStream)
+		{
+			Headers.ContentType = MediaTypeHeaderValue.Parse(mediaType);
+
+			m_memoryStream = memoryStream;
+		}
+
+		protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
+		{
+			m_memoryStream.Position = 0;
+			return m_memoryStream.CopyToAsync(stream);
+		}
+
+		protected override bool TryComputeLength(out long length)
+		{
+			length = m_memoryStream.Length;
+			return true;
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			try
+			{
+				if (disposing)
+					m_memoryStream.Dispose();
+			}
+			finally
+			{
+				base.Dispose(disposing);
+			}
+		}
+
+		private readonly Stream m_memoryStream;
+	}
+
+	private readonly bool m_forceAsyncIO;
 	private readonly Func<Stream>? m_memoryStreamCreator;
-	private readonly HttpContentSerializer m_contentSerializer;
 }

--- a/src/Facility.Core/Http/ServiceHttpHandler.cs
+++ b/src/Facility.Core/Http/ServiceHttpHandler.cs
@@ -23,9 +23,9 @@ public abstract class ServiceHttpHandler : DelegatingHandler
 
 		m_rootPath = (settings.RootPath ?? "").TrimEnd('/');
 		m_synchronous = settings.Synchronous;
-		m_contentSerializer = (settings.ContentSerializer ?? defaults.ContentSerializer ?? HttpContentSerializer.Legacy).WithMemoryStreamCreatorIfNotNull(settings.MemoryStreamCreator);
-		m_bytesSerializer = (settings.BytesSerializer ?? BytesHttpContentSerializer.Instance).WithMemoryStreamCreatorIfNotNull(settings.MemoryStreamCreator);
-		m_textSerializer = (settings.TextSerializer ?? TextHttpContentSerializer.Instance).WithMemoryStreamCreatorIfNotNull(settings.MemoryStreamCreator);
+		m_contentSerializer = settings.ContentSerializer ?? defaults.ContentSerializer ?? HttpContentSerializer.Legacy;
+		m_bytesSerializer = settings.BytesSerializer ?? BytesHttpContentSerializer.Instance;
+		m_textSerializer = settings.TextSerializer ?? TextHttpContentSerializer.Instance;
 		m_aspects = settings.Aspects;
 		m_skipRequestValidation = settings.SkipRequestValidation;
 		m_skipResponseValidation = settings.SkipResponseValidation;

--- a/src/Facility.Core/Http/ServiceHttpHandlerSettings.cs
+++ b/src/Facility.Core/Http/ServiceHttpHandlerSettings.cs
@@ -31,11 +31,6 @@ public class ServiceHttpHandlerSettings
 	public HttpContentSerializer? TextSerializer { get; set; }
 
 	/// <summary>
-	/// The memory stream creator to be used by content serializers (optional).
-	/// </summary>
-	public Func<Stream>? MemoryStreamCreator { get; set; }
-
-	/// <summary>
 	/// The aspects used when receiving requests and sending responses.
 	/// </summary>
 	public IReadOnlyList<ServiceHttpHandlerAspect>? Aspects { get; set; }

--- a/src/Facility.Core/Http/StandardHttpContentSerializer.cs
+++ b/src/Facility.Core/Http/StandardHttpContentSerializer.cs
@@ -30,7 +30,7 @@ internal sealed class StandardHttpContentSerializer : HttpContentSerializer
 #else
 			using var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
 #endif
-			var deserializedContent = m_serializer.FromStream(stream, objectType);
+			var deserializedContent = await m_serializer.FromStreamAsync(stream, objectType, cancellationToken).ConfigureAwait(false);
 			if (deserializedContent is null)
 				return ServiceResult.Failure(HttpServiceErrors.CreateInvalidContent("Content must not be empty."));
 			return ServiceResult.Success(deserializedContent);
@@ -52,7 +52,7 @@ internal sealed class StandardHttpContentSerializer : HttpContentSerializer
 		}
 
 		protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
-			m_serializer.ToStream(m_content, stream);
+			await m_serializer.ToStreamAsync(m_content, stream, CancellationToken.None).ConfigureAwait(false);
 
 		protected override bool TryComputeLength(out long length)
 		{

--- a/src/Facility.Core/Http/StandardHttpContentSerializer.cs
+++ b/src/Facility.Core/Http/StandardHttpContentSerializer.cs
@@ -5,22 +5,17 @@ namespace Facility.Core.Http;
 
 internal sealed class StandardHttpContentSerializer : HttpContentSerializer
 {
-	public StandardHttpContentSerializer(ServiceSerializer serializer, Func<Stream>? memoryStreamCreator = null)
+	public StandardHttpContentSerializer(ServiceSerializer serializer)
 	{
 		m_serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
-		m_memoryStreamCreator = memoryStreamCreator;
 	}
 
 	protected override string DefaultMediaTypeCore => m_serializer.DefaultMediaType;
 
 	protected override bool IsSupportedMediaTypeCore(string mediaType) => mediaType == m_serializer.DefaultMediaType;
 
-	protected override HttpContent CreateHttpContentCore(object content, string? mediaType)
-	{
-		var memoryStream = CreateMemoryStream();
-		m_serializer.ToStream(content, memoryStream);
-		return new DelegateHttpContent(mediaType ?? DefaultMediaType, memoryStream);
-	}
+	protected override HttpContent CreateHttpContentCore(object content, string? mediaType) =>
+		new DelegateHttpContent(mediaType ?? DefaultMediaType, content, m_serializer);
 
 	protected override async Task<ServiceResult<object>> ReadHttpContentAsyncCore(Type objectType, HttpContent content, CancellationToken cancellationToken)
 	{
@@ -35,10 +30,7 @@ internal sealed class StandardHttpContentSerializer : HttpContentSerializer
 #else
 			using var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
 #endif
-			using var memoryStream = CreateMemoryStream();
-			await stream.CopyToAsync(memoryStream, 80 * 1024, cancellationToken).ConfigureAwait(false);
-			memoryStream.Seek(0, SeekOrigin.Begin);
-			var deserializedContent = m_serializer.FromStream(memoryStream, objectType);
+			var deserializedContent = m_serializer.FromStream(stream, objectType);
 			if (deserializedContent is null)
 				return ServiceResult.Failure(HttpServiceErrors.CreateInvalidContent("Content must not be empty."));
 			return ServiceResult.Success(deserializedContent);
@@ -49,48 +41,28 @@ internal sealed class StandardHttpContentSerializer : HttpContentSerializer
 		}
 	}
 
-	protected override HttpContentSerializer WithMemoryStreamCreatorCore(Func<Stream> memoryStreamCreator) =>
-		new StandardHttpContentSerializer(m_serializer, memoryStreamCreator);
-
-	private Stream CreateMemoryStream() => m_memoryStreamCreator is null ? new MemoryStream() : m_memoryStreamCreator();
-
 	private sealed class DelegateHttpContent : HttpContent
 	{
-		public DelegateHttpContent(string mediaType, Stream memoryStream)
+		public DelegateHttpContent(string mediaType, object content, ServiceSerializer serializer)
 		{
 			Headers.ContentType = MediaTypeHeaderValue.Parse(mediaType);
 
-			m_memoryStream = memoryStream;
+			m_content = content;
+			m_serializer = serializer;
 		}
 
-		protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context)
-		{
-			m_memoryStream.Position = 0;
-			return m_memoryStream.CopyToAsync(stream);
-		}
+		protected override async Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
+			m_serializer.ToStream(m_content, stream);
 
 		protected override bool TryComputeLength(out long length)
 		{
-			length = m_memoryStream.Length;
-			return true;
+			length = -1L;
+			return false;
 		}
 
-		protected override void Dispose(bool disposing)
-		{
-			try
-			{
-				if (disposing)
-					m_memoryStream.Dispose();
-			}
-			finally
-			{
-				base.Dispose(disposing);
-			}
-		}
-
-		private readonly Stream m_memoryStream;
+		private readonly object m_content;
+		private readonly ServiceSerializer m_serializer;
 	}
 
 	private readonly ServiceSerializer m_serializer;
-	private readonly Func<Stream>? m_memoryStreamCreator;
 }

--- a/src/Facility.Core/Http/StandardHttpContentSerializer.cs
+++ b/src/Facility.Core/Http/StandardHttpContentSerializer.cs
@@ -27,7 +27,11 @@ internal sealed class StandardHttpContentSerializer : HttpContentSerializer
 		try
 		{
 #if NET6_0_OR_GREATER
-			using var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+			var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
+			await using var streamScope = stream.ConfigureAwait(false);
+#elif NETSTANDARD2_1_OR_GREATER
+			var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
+			await using var streamScope = stream.ConfigureAwait(false);
 #else
 			using var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
 #endif

--- a/src/Facility.Core/ServiceSerializer.cs
+++ b/src/Facility.Core/ServiceSerializer.cs
@@ -15,25 +15,16 @@ public abstract class ServiceSerializer
 	/// <summary>
 	/// Serializes a value.
 	/// </summary>
-	public abstract void ToStream(object? value, Stream stream);
+	public abstract Task ToStreamAsync(object? value, Stream stream, CancellationToken cancellationToken);
 
 	/// <summary>
 	/// Deserializes a value.
 	/// </summary>
-	public abstract object? FromStream(Stream stream, Type type);
+	public abstract Task<object?> FromStreamAsync(Stream stream, Type type, CancellationToken cancellationToken);
 
 	/// <summary>
 	/// Clones a value by serializing and deserializing.
 	/// </summary>
 	[return: NotNullIfNotNull("value")]
-	public virtual T Clone<T>(T value)
-	{
-		if (value is null)
-			return default!;
-
-		using var memoryStream = new MemoryStream();
-		ToStream(value, memoryStream);
-		memoryStream.Position = 0;
-		return (T) FromStream(memoryStream, typeof(T))!;
-	}
+	public abstract T Clone<T>(T value);
 }

--- a/src/FacilityConformance/FacilityConformance.csproj
+++ b/src/FacilityConformance/FacilityConformance.csproj
@@ -20,7 +20,6 @@
 
   <ItemGroup>
     <PackageReference Include="ArgsReading" Version="2.3.2" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <FrameworkReference Include="Microsoft.AspNetCore.App" />
   </ItemGroup>
 

--- a/src/FacilityConformance/FacilityConformanceApp.cs
+++ b/src/FacilityConformance/FacilityConformanceApp.cs
@@ -70,7 +70,7 @@ public sealed class FacilityConformanceApp
 
 #pragma warning disable CS0618 // Type or member is obsolete
 		if (serializerName is "obsoletejson")
-			contentSerializer = new JsonHttpContentSerializer(new JsonHttpContentSerializerSettings());
+			contentSerializer = new JsonHttpContentSerializer(new JsonHttpContentSerializerSettings { ForceAsyncIO = true });
 #pragma warning restore CS0618 // Type or member is obsolete
 
 		var jsonSerializer = serializer as JsonServiceSerializer ?? NewtonsoftJsonServiceSerializer.Instance;
@@ -91,7 +91,7 @@ public sealed class FacilityConformanceApp
 				});
 
 			await new WebHostBuilder()
-				.UseKestrel(options => options.AllowSynchronousIO = false)
+				.UseKestrel(options => options.AllowSynchronousIO = serializerName is "newtonsoftjson")
 				.UseUrls(url)
 				.Configure(app => app.Run(httpContext => HostAsync(httpContext, service, contentSerializer)))
 				.Build()

--- a/src/FacilityConformance/FacilityConformanceApp.cs
+++ b/src/FacilityConformance/FacilityConformanceApp.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Http.Extensions;
-using Microsoft.IO;
 
 namespace FacilityConformance;
 
@@ -67,11 +66,11 @@ public sealed class FacilityConformanceApp
 			"newtonsoftjson" or "obsoletejson" => NewtonsoftJsonServiceSerializer.Instance,
 			_ => throw new ArgsReaderException("Unsupported serializer."),
 		};
-		var contentSerializer = HttpContentSerializer.Create(serializer).WithMemoryStreamCreator(s_memoryStreamManager.GetStream);
+		var contentSerializer = HttpContentSerializer.Create(serializer);
 
 #pragma warning disable CS0618 // Type or member is obsolete
 		if (serializerName is "obsoletejson")
-			contentSerializer = new JsonHttpContentSerializer(new JsonHttpContentSerializerSettings { MemoryStreamCreator = s_memoryStreamManager.GetStream });
+			contentSerializer = new JsonHttpContentSerializer(new JsonHttpContentSerializerSettings());
 #pragma warning restore CS0618 // Type or member is obsolete
 
 		var jsonSerializer = serializer as JsonServiceSerializer ?? NewtonsoftJsonServiceSerializer.Instance;
@@ -92,7 +91,7 @@ public sealed class FacilityConformanceApp
 				});
 
 			await new WebHostBuilder()
-				.UseKestrel()
+				.UseKestrel(options => options.AllowSynchronousIO = false)
 				.UseUrls(url)
 				.Configure(app => app.Run(httpContext => HostAsync(httpContext, service, contentSerializer)))
 				.Build()
@@ -285,8 +284,6 @@ public sealed class FacilityConformanceApp
 			}
 		}
 	}
-
-	private static readonly RecyclableMemoryStreamManager s_memoryStreamManager = new();
 
 	private readonly string m_fsdText;
 	private readonly string m_testsJson;

--- a/tests/Facility.ConformanceApi.UnitTests/ConformanceTests.cs
+++ b/tests/Facility.ConformanceApi.UnitTests/ConformanceTests.cs
@@ -14,7 +14,7 @@ public sealed class ConformanceTests : ServiceSerializerTestsBase, IDisposable
 		: base(serializer)
 	{
 		m_tests = CreateTestProvider(JsonSerializer);
-		m_contentSerializer = HttpContentSerializer.Create(Serializer).WithMemoryStreamCreator(MemoryStreamManager.GetStream);
+		m_contentSerializer = HttpContentSerializer.Create(Serializer);
 
 		var handler = new ConformanceApiHttpHandler(
 				service: new ConformanceApiService(new ConformanceApiServiceSettings { Tests = m_tests, JsonSerializer = JsonSerializer }),

--- a/tests/Facility.ConformanceApi.UnitTests/DtoValidationTests.cs
+++ b/tests/Facility.ConformanceApi.UnitTests/DtoValidationTests.cs
@@ -312,7 +312,7 @@ public sealed class DtoValidationTests : ServiceSerializerTestsBase
 	private HttpClientConformanceApi CreateHttpApi(bool skipClientValidation = false, bool skipServerValidation = false, RequiredResponseDto? requiredResponse = null)
 	{
 		var service = new FakeConformanceApiService(Serializer, requiredResponse: requiredResponse);
-		var contentSerializer = HttpContentSerializer.Create(Serializer).WithMemoryStreamCreator(MemoryStreamManager.GetStream);
+		var contentSerializer = HttpContentSerializer.Create(Serializer);
 		var settings = new ServiceHttpHandlerSettings
 		{
 			SkipRequestValidation = skipServerValidation,

--- a/tests/Facility.ConformanceApi.UnitTests/Facility.ConformanceApi.UnitTests.csproj
+++ b/tests/Facility.ConformanceApi.UnitTests/Facility.ConformanceApi.UnitTests.csproj
@@ -11,7 +11,6 @@
 
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.2.0" />
-    <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="NCrunch.Framework" Version="4.7.0.4" />
     <PackageReference Include="NUnit" Version="3.13.2" />

--- a/tests/Facility.ConformanceApi.UnitTests/ServiceSerializerTestsBase.cs
+++ b/tests/Facility.ConformanceApi.UnitTests/ServiceSerializerTestsBase.cs
@@ -1,5 +1,4 @@
 using Facility.Core;
-using Microsoft.IO;
 
 namespace Facility.ConformanceApi.UnitTests;
 
@@ -20,6 +19,4 @@ public abstract class ServiceSerializerTestsBase
 	protected ServiceSerializer Serializer { get; }
 
 	protected JsonServiceSerializer JsonSerializer { get; }
-
-	protected static RecyclableMemoryStreamManager MemoryStreamManager { get; } = new();
 }


### PR DESCRIPTION
This PR eliminates all need for memory streams by serializing/deserializing directly from the DTO, asynchronously when possible.

I believe this will use "chunked transfer encoding" by default, but I haven't been able to demonstrate that. If that turns out to be a problem, I think we could add an option that calls `LoadIntoBufferAsync` on the `HttpContent` after creating it but before using it.