### PR TITLE
Disable chunked transfer encoding by default.

### DIFF
--- a/src/Facility.Core/Http/HttpClientService.cs
+++ b/src/Facility.Core/Http/HttpClientService.cs
@@ -19,6 +19,7 @@ public abstract class HttpClientService
 		m_synchronous = settings.Synchronous;
 		m_skipRequestValidation = settings.SkipRequestValidation;
 		m_skipResponseValidation = settings.SkipResponseValidation;
+		m_allowChunkedTransfer = settings.AllowChunkedTransfer;
 
 		var baseUri = settings.BaseUri ?? defaults.BaseUri;
 		m_baseUrl = baseUri == null ? "/" : (baseUri.IsAbsoluteUri ? baseUri.AbsoluteUri : baseUri.OriginalString).TrimEnd('/') + "/";
@@ -94,6 +95,8 @@ public abstract class HttpClientService
 			{
 				var contentType = mapping.RequestBodyContentType ?? requestHeaders?.GetContentType();
 				httpRequest.Content = GetHttpContentSerializer(requestBody.GetType()).CreateHttpContent(requestBody, contentType);
+				if (!m_allowChunkedTransfer)
+					await httpRequest.Content.LoadIntoBufferAsync().ConfigureAwait(false);
 			}
 
 			// send the HTTP request and get the HTTP response
@@ -276,5 +279,6 @@ public abstract class HttpClientService
 	private readonly bool m_synchronous;
 	private readonly bool m_skipRequestValidation;
 	private readonly bool m_skipResponseValidation;
+	private readonly bool m_allowChunkedTransfer;
 	private readonly string m_baseUrl;
 }

--- a/src/Facility.Core/Http/HttpClientServiceSettings.cs
+++ b/src/Facility.Core/Http/HttpClientServiceSettings.cs
@@ -31,6 +31,12 @@ public sealed class HttpClientServiceSettings
 	public HttpContentSerializer? TextSerializer { get; set; }
 
 	/// <summary>
+	/// True to allow chunked transfer encoding (default false).
+	/// </summary>
+	/// <remarks>If false, the response is serialized into memory before sending it to the service.</remarks>
+	public bool AllowChunkedTransfer { get; set; }
+
+	/// <summary>
 	/// The aspects used when sending requests and receiving responses (optional).
 	/// </summary>
 	public IReadOnlyList<HttpClientServiceAspect>? Aspects { get; set; }

--- a/src/Facility.Core/Http/ServiceHttpHandlerSettings.cs
+++ b/src/Facility.Core/Http/ServiceHttpHandlerSettings.cs
@@ -31,6 +31,12 @@ public class ServiceHttpHandlerSettings
 	public HttpContentSerializer? TextSerializer { get; set; }
 
 	/// <summary>
+	/// True to allow chunked transfer encoding (default false).
+	/// </summary>
+	/// <remarks>If false, the response is serialized into memory before sending it to the client.</remarks>
+	public bool AllowChunkedTransfer { get; set; }
+
+	/// <summary>
 	/// The aspects used when receiving requests and sending responses.
 	/// </summary>
 	public IReadOnlyList<ServiceHttpHandlerAspect>? Aspects { get; set; }


### PR DESCRIPTION
In the benchmarks, disabling chunked transfer encoding hurts performance and allocates more memory. So maybe we should enable it by default and allow clients to disable it. Change the setting to `DisableChunkedTransfer` or `DisallowChunkedTransfer`? Or just use `true` for the default of `AllowChunkedTransfer`?

Chunked:
```
|   Method | UserCount |     Serializer |     Mean |     Error |    StdDev |     Gen 0 |    Gen 1 |   Gen 2 | Allocated |
|--------- |---------- |--------------- |---------:|----------:|----------:|----------:|---------:|--------:|----------:|
| GetUsers |      1000 |    MessagePack | 2.043 ms | 0.0045 ms | 0.0133 ms |  105.4688 |  50.7813 |       - |    807 KB |
| GetUsers |      1000 | NewtonsoftJson | 8.700 ms | 0.0298 ms | 0.0844 ms | 1250.0000 | 359.3750 | 46.8750 |  9,677 KB |
| GetUsers |      1000 | SystemTextJson | 3.455 ms | 0.0067 ms | 0.0188 ms |  152.3438 |  74.2188 |       - |  1,173 KB |
```

Not chunked:
```
|   Method | UserCount |     Serializer |     Mean |     Error |    StdDev |   Median |     Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|--------- |---------- |--------------- |---------:|----------:|----------:|---------:|----------:|---------:|---------:|----------:|
| GetUsers |      1000 |    MessagePack | 2.284 ms | 0.0034 ms | 0.0099 ms | 2.285 ms |  132.8125 |  85.9375 |  42.9688 |  1,062 KB |
| GetUsers |      1000 | NewtonsoftJson | 9.651 ms | 0.1717 ms | 0.6350 ms | 9.452 ms | 1000.0000 |        - |        - | 10,190 KB |
| GetUsers |      1000 | SystemTextJson | 4.408 ms | 0.0077 ms | 0.0222 ms | 4.408 ms |  218.7500 | 109.3750 | 109.3750 |  1,621 KB |
```