### PR TITLE
Support JObject properties with System.Text.Json serializer.

### DIFF
--- a/src/Facility.Core/SystemTextJsonServiceSerializer.cs
+++ b/src/Facility.Core/SystemTextJsonServiceSerializer.cs
@@ -154,8 +154,24 @@ public sealed class SystemTextJsonServiceSerializer : JsonServiceSerializer
 	{
 	}
 
+	private sealed class NewtonsoftJsonLinqSystemTextJsonConverter<T> : JsonConverter<T>
+		where T : Newtonsoft.Json.Linq.JToken
+	{
+		public override T Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
+			(T) Newtonsoft.Json.Linq.JToken.Parse(JsonNode.Parse(ref reader)?.ToJsonString());
+
+		public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options) =>
+			writer.WriteRawValue(value.ToString(Newtonsoft.Json.Formatting.None));
+	}
+
 	private static readonly JsonSerializerOptions s_jsonSerializerOptions = new(JsonSerializerDefaults.Web)
 	{
 		DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+		Converters =
+		{
+			new NewtonsoftJsonLinqSystemTextJsonConverter<Newtonsoft.Json.Linq.JObject>(),
+			new NewtonsoftJsonLinqSystemTextJsonConverter<Newtonsoft.Json.Linq.JArray>(),
+			new NewtonsoftJsonLinqSystemTextJsonConverter<Newtonsoft.Json.Linq.JValue>(),
+		},
 	};
 }

--- a/tests/Facility.Core.UnitTests/JsonServiceSerializerTests.cs
+++ b/tests/Facility.Core.UnitTests/JsonServiceSerializerTests.cs
@@ -118,4 +118,20 @@ public sealed class JsonServiceSerializerTests : JsonServiceSerializerTestsBase
 		var so2 = JsonSerializer.FromJson<ServiceObject>(JsonSerializer.ToJson(so1));
 		Assert.IsTrue(so1.IsEquivalentTo(so2));
 	}
+
+	[Test]
+	public void RoundTripJObject()
+	{
+		var legacy1 = new LegacyObjectDto { Extra = new JObject { ["foo"] = "bar" } };
+		var legacy2 = JsonSerializer.FromJson<LegacyObjectDto>(JsonSerializer.ToJson(legacy1));
+		Assert.IsTrue(legacy1.IsEquivalentTo(legacy2));
+	}
+
+	[Test]
+	public void RoundTripNullJObject()
+	{
+		var legacy1 = new LegacyObjectDto();
+		var legacy2 = JsonSerializer.FromJson<LegacyObjectDto>(JsonSerializer.ToJson(legacy1));
+		Assert.IsTrue(legacy1.IsEquivalentTo(legacy2));
+	}
 }

--- a/tests/Facility.Core.UnitTests/LegacyObjectDto.cs
+++ b/tests/Facility.Core.UnitTests/LegacyObjectDto.cs
@@ -1,0 +1,11 @@
+using Newtonsoft.Json.Linq;
+
+namespace Facility.Core.UnitTests;
+
+public class LegacyObjectDto : ServiceDto<LegacyObjectDto>
+{
+	public JObject? Extra { get; set; }
+
+	public override bool IsEquivalentTo(LegacyObjectDto? other) =>
+		other != null && ServiceDataUtility.AreEquivalentObjects(other.Extra, Extra);
+}


### PR DESCRIPTION
If we inadvertently use the `System.Text.Json` serializer with a DTO with a `JObject` property, we should not serialize the wrong JSON (which is what happens without this PR). We should instead throw an exception or just work. This PR takes the latter approach.