### PR TITLE
Improve performance of NewtonsoftJsonServiceSerializer.Clone

### DIFF
--- a/src/Facility.Core/NewtonsoftJsonServiceSerializer.cs
+++ b/src/Facility.Core/NewtonsoftJsonServiceSerializer.cs
@@ -93,10 +93,8 @@ public sealed class NewtonsoftJsonServiceSerializer : JsonServiceSerializer
 		if (value is null)
 			return default!;
 
-		using var memoryStream = new MemoryStream();
-		ToStream(value, memoryStream);
-		memoryStream.Position = 0;
-		return (T) FromStream(memoryStream, typeof(T))!;
+		var serializedValue = ToJson(value);
+		return FromJson<T>(serializedValue)!;
 	}
 
 	/// <summary>


### PR DESCRIPTION
String serialization/deserialize is faster and allocates significantly less memory than the stream methods.

Using the benchmark tests from the MessagePack PR:

Existing implementation:
```
|   Method | UserCount |     Serializer |      Mean |     Error |    StdDev |    Median |     Gen 0 |   Gen 1 | Allocated |
|--------- |---------- |--------------- |----------:|----------:|----------:|----------:|----------:|--------:|----------:|
| GetUsers |         1 | NewtonsoftJson | 12.311 ms | 0.2456 ms | 1.3332 ms | 11.982 ms | 2000.0000 |       - |  9,258 KB |
| GetUsers |        10 | NewtonsoftJson | 12.495 ms | 0.2476 ms | 1.4515 ms | 12.239 ms | 2000.0000 |       - |  9,267 KB |
| GetUsers |       100 | NewtonsoftJson | 12.758 ms | 0.2551 ms | 1.7427 ms | 12.271 ms | 2000.0000 |       - |  9,302 KB |
| GetUsers |      1000 | NewtonsoftJson | 15.092 ms | 0.2944 ms | 1.6007 ms | 14.652 ms | 1000.0000 |       - |  9,678 KB |
```

This change:
```
|   Method | UserCount |     Serializer |      Mean |     Error |    StdDev |    Median |    Gen 0 |   Gen 1 | Allocated |
|--------- |---------- |--------------- |----------:|----------:|----------:|----------:|---------:|--------:|----------:|
| GetUsers |         1 | NewtonsoftJson |  8.916 ms | 0.1782 ms | 1.2386 ms |  8.685 ms |        - |       - |  4,508 KB |
| GetUsers |        10 | NewtonsoftJson |  8.849 ms | 0.1764 ms | 1.2449 ms |  8.633 ms |        - |       - |  4,515 KB |
| GetUsers |       100 | NewtonsoftJson |  9.062 ms | 0.1811 ms | 1.3211 ms |  8.803 ms |        - |       - |  4,553 KB |
| GetUsers |      1000 | NewtonsoftJson | 11.986 ms | 0.2394 ms | 1.4950 ms | 11.636 ms |        - |       - |  4,929 KB |
```