### PR TITLE
Trim beginning slash from path.

### DIFF
--- a/src/Facility.ConformanceApi/Testing/ConformanceApiTester.cs
+++ b/src/Facility.ConformanceApi/Testing/ConformanceApiTester.cs
@@ -89,7 +89,7 @@ public sealed class ConformanceApiTester
 				if (test.HttpRequest.Path is null)
 					return Failure("HTTP request missing path.");
 
-				var httpRequest = new HttpRequestMessage(new HttpMethod(test.HttpRequest.Method), test.HttpRequest.Path);
+				var httpRequest = new HttpRequestMessage(new HttpMethod(test.HttpRequest.Method), test.HttpRequest.Path.TrimStart('/'));
 				var httpResponse = await m_httpClient.SendAsync(httpRequest, cancellationToken).ConfigureAwait(false);
 				if (!httpResponse.IsSuccessStatusCode)
 					return Failure($"Got {(int) httpResponse.StatusCode} {httpResponse.ReasonPhrase}: {await httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false)}");


### PR DESCRIPTION
When running conformance tests with explicit http requests (e.g. `checkPathHttpPathCase`) and a url with a prefix (e.g. `http://example.com/prefix/`), the prefix is not included in the actual request.

The `HttpClientService` trims the beginning slash and so should the `ConformanceApiTester`.
