### PR TITLE
Add disable-chunked-transfer to conformance app.

### DIFF
--- a/src/FacilityConformance/FacilityConformanceApp.cs
+++ b/src/FacilityConformance/FacilityConformanceApp.cs
@@ -99,6 +99,7 @@ public sealed class FacilityConformanceApp
 		if (command == "test")
 		{
 			var baseUri = new Uri(argsReader.ReadOption("url") ?? defaultUrl);
+			bool disableChunkedTransfer = argsReader.ReadFlag("disable-chunked-transfer");
 			var testNames = argsReader.ReadArguments();
 			argsReader.VerifyComplete();
 
@@ -107,6 +108,7 @@ public sealed class FacilityConformanceApp
 				{
 					BaseUri = baseUri,
 					ContentSerializer = contentSerializer,
+					DisableChunkedTransfer = disableChunkedTransfer,
 				});
 
 			var tester = new ConformanceApiTester(


### PR DESCRIPTION
Unfortunately Azure Functions has a bug that doesn't allow it to work with chunked requests right now. https://github.com/Azure/azure-functions-host/issues/4926

This flag made the "usage" output pretty ugly because it is so long, so I opted to leave it out (similar to "--serializer" which I'm not sure was an intentional ommission or not). Totally open to another way!