### PR TITLE
Support reading Boolean from string.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,7 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>2.19.0</VersionPrefix>
+    <VersionPrefix>2.20.0</VersionPrefix>
     <LangVersion>11.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 2.20.0
+
+* Support reading Boolean from string.
+
 ## 2.19.0
 
 * Support `extern` data and enum types.

--- a/tests/Facility.Core.UnitTests/JsonServiceSerializerTests.cs
+++ b/tests/Facility.Core.UnitTests/JsonServiceSerializerTests.cs
@@ -18,7 +18,7 @@ public sealed class JsonServiceSerializerTests : JsonServiceSerializerTestsBase
 	public void CamelCase()
 	{
 		var dto = ValueDto.Create(true);
-		var json = "{\"booleanValue\":true}";
+		const string json = """{"booleanValue":true}""";
 
 		JsonSerializer.ToJson(dto).Should().Be(json);
 		JsonSerializer.FromJson<ValueDto>(json).Should().BeDto(dto);
@@ -28,7 +28,7 @@ public sealed class JsonServiceSerializerTests : JsonServiceSerializerTestsBase
 	public void CamelCaseExceptDictionaryKeys()
 	{
 		var dto = ValueDto.Create(new Dictionary<string, bool> { ["Key"] = true });
-		var json = "{\"booleanMapValue\":{\"Key\":true}}";
+		const string json = """{"booleanMapValue":{"Key":true}}""";
 
 		JsonSerializer.ToJson(dto).Should().Be(json);
 		JsonSerializer.FromJson<ValueDto>(json).Should().BeDto(dto);
@@ -38,7 +38,7 @@ public sealed class JsonServiceSerializerTests : JsonServiceSerializerTestsBase
 	public void DateParseHandlingNone()
 	{
 		var dto = ValueDto.Create("2016-10-21T15:31:00Z");
-		var json = $"{{\"stringValue\":\"{dto.StringValue}\"}}";
+		var json = $$"""{"stringValue":"{{dto.StringValue}}"}""";
 
 		JsonSerializer.ToJson(dto).Should().Be(json);
 		JsonSerializer.FromJson<ValueDto>(json).Should().BeDto(dto);
@@ -48,7 +48,7 @@ public sealed class JsonServiceSerializerTests : JsonServiceSerializerTestsBase
 	public void NullValueHandlingIgnore()
 	{
 		var dto = ValueDto.Create(default(bool?));
-		var json = "{}";
+		const string json = "{}";
 
 		JsonSerializer.ToJson(dto).Should().Be(json);
 		JsonSerializer.FromJson<ValueDto>(json).Should().BeDto(dto);
@@ -58,7 +58,7 @@ public sealed class JsonServiceSerializerTests : JsonServiceSerializerTestsBase
 	public void MissingMemberHandlingIgnore()
 	{
 		var dto = ValueDto.Create(true);
-		var json = "{\"booleanValue\":true,\"missing\":false}";
+		const string json = """{"booleanValue":true,"missing":false}""";
 		JsonSerializer.FromJson<ValueDto>(json).Should().BeDto(dto);
 	}
 
@@ -66,7 +66,7 @@ public sealed class JsonServiceSerializerTests : JsonServiceSerializerTestsBase
 	public void MetadataPropertyHandlingIgnore()
 	{
 		var dto = ValueDto.Create(true);
-		var json = "{\"$ref\":\"xyzzy\",\"booleanValue\":true}";
+		const string json = """{"$ref":"xyzzy","booleanValue":true}""";
 		JsonSerializer.FromJson<ValueDto>(json).Should().BeDto(dto);
 	}
 
@@ -80,7 +80,7 @@ public sealed class JsonServiceSerializerTests : JsonServiceSerializerTestsBase
 			invalidRequest,
 			invalidResponse,
 		});
-		var json = "{\"errorArrayValue\":[{\"code\":\"InvalidRequest\"},{\"code\":\"InvalidResponse\"}]}";
+		const string json = """{"errorArrayValue":[{"code":"InvalidRequest"},{"code":"InvalidResponse"}]}""";
 
 		JsonSerializer.ToJson(dto).Should().Be(json);
 		JsonSerializer.FromJson<ValueDto>(json).Should().BeDto(dto);
@@ -97,7 +97,7 @@ public sealed class JsonServiceSerializerTests : JsonServiceSerializerTestsBase
 			["response"] = invalidResponse,
 		});
 
-		var json = "{\"errorMapValue\":{\"request\":{\"code\":\"InvalidRequest\"},\"response\":{\"code\":\"InvalidResponse\"}}}";
+		const string json = """{"errorMapValue":{"request":{"code":"InvalidRequest"},"response":{"code":"InvalidResponse"}}}""";
 
 		JsonSerializer.ToJson(dto).Should().Be(json);
 		JsonSerializer.FromJson<ValueDto>(json).Should().BeDto(dto);
@@ -166,5 +166,19 @@ public sealed class JsonServiceSerializerTests : JsonServiceSerializerTestsBase
 		Assert.AreEqual(0, JsonSerializer.FromJson<JArray>(JsonSerializer.ToJson(new JArray()))!.Count);
 		Assert.AreEqual("hi", (string) JsonSerializer.FromJson<JValue>(JsonSerializer.ToJson((JValue) "hi"))!);
 		Assert.IsTrue((bool) JsonSerializer.FromJson<JToken>(JsonSerializer.ToJson((JToken) true))!);
+	}
+
+	[Test]
+	public void AllowReadingNumberFromString()
+	{
+		JsonSerializer.FromJson<ValueDto>("""{"integerValue":"42"}""").Should().BeDto(ValueDto.Create(42));
+	}
+
+	[Test]
+	public void AllowReadingBooleanFromString()
+	{
+		JsonSerializer.FromJson<ValueDto>("""{"booleanValue":"true"}""").Should().BeDto(ValueDto.Create(true));
+		JsonSerializer.FromJson<ValueDto>("""{"booleanValue":"false"}""").Should().BeDto(ValueDto.Create(false));
+		JsonSerializer.FromJson<ValueDto>("""{"booleanValue":null}""").Should().BeDto(new ValueDto());
 	}
 }

--- a/tests/Facility.Core.UnitTests/ValueDto.cs
+++ b/tests/Facility.Core.UnitTests/ValueDto.cs
@@ -15,6 +15,8 @@ public sealed class ValueDto : ServiceDto<ValueDto>
 
 	public static ValueDto Create(IReadOnlyDictionary<string, ServiceErrorDto> value) => new ValueDto { ErrorMapValue = value };
 
+	public static ValueDto Create(int? value) => new ValueDto { IntegerValue = value };
+
 	[Key(0)]
 	public bool? BooleanValue { get; set; }
 
@@ -30,11 +32,15 @@ public sealed class ValueDto : ServiceDto<ValueDto>
 	[Key(4)]
 	public IReadOnlyDictionary<string, ServiceErrorDto>? ErrorMapValue { get; set; }
 
+	[Key(5)]
+	public int? IntegerValue { get; set; }
+
 	public override bool IsEquivalentTo(ValueDto? other) =>
 		other != null &&
 		BooleanValue == other.BooleanValue &&
 		StringValue == other.StringValue &&
 		ServiceDataUtility.AreEquivalentFieldValues(ErrorArrayValue, other.ErrorArrayValue) &&
 		ServiceDataUtility.AreEquivalentFieldValues(BooleanMapValue, other.BooleanMapValue) &&
-		ServiceDataUtility.AreEquivalentFieldValues(ErrorMapValue, other.ErrorMapValue);
+		ServiceDataUtility.AreEquivalentFieldValues(ErrorMapValue, other.ErrorMapValue) &&
+		IntegerValue == other.IntegerValue;
 }


### PR DESCRIPTION
This provides better backward compatibility when upgrading a Facility API from Newtonsoft.Json to System.Text.Json.

This is not meant to implement full backward compatibility with Newtonsoft.Json, but only to handle a case that's come up multiple times: unintentionally sending `"true"` or `"false"` from a JavaScript client.