### PR TITLE
Allow missing or empty HTTP content to be treated as an empty DTO.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>2.29.1</VersionPrefix>
-    <PackageValidationBaselineVersion>2.29.0</PackageValidationBaselineVersion>
+    <VersionPrefix>2.29.2</VersionPrefix>
+    <PackageValidationBaselineVersion>2.29.1</PackageValidationBaselineVersion>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 2.29.2
+
+* Allow missing or empty HTTP content to be treated as an empty DTO for backward compatibility with method bodies that previously had no fields.
+
 ## 2.29.1
 
 * Improve nullable analysis of `ServiceResult.Error`.

--- a/src/Facility.Core/Http/HttpClientService.cs
+++ b/src/Facility.Core/Http/HttpClientService.cs
@@ -154,7 +154,7 @@ public abstract class HttpClientService
 			if (responseMapping.ResponseBodyType != null)
 			{
 				var serializer = GetHttpContentSerializer(responseMapping.ResponseBodyType);
-				var responseResult = await serializer.ReadHttpContentAsync(
+				var responseResult = await serializer.ReadHttpContentOrNullAsync(
 					responseMapping.ResponseBodyType, httpResponse.Content, cancellationToken).ConfigureAwait(false);
 				if (responseResult.IsFailure)
 				{
@@ -345,9 +345,9 @@ public abstract class HttpClientService
 	/// </summary>
 	protected virtual async Task<ServiceErrorDto> CreateErrorFromHttpResponseAsync(HttpResponseMessage response, CancellationToken cancellationToken)
 	{
-		var result = await ContentSerializer.ReadHttpContentAsync<ServiceErrorDto>(response.Content, cancellationToken).ConfigureAwait(false);
+		var result = await ContentSerializer.ReadHttpContentOrNullAsync<ServiceErrorDto>(response.Content, cancellationToken).ConfigureAwait(false);
 
-		if (result.IsFailure || string.IsNullOrWhiteSpace(result.Value.Code))
+		if (result.IsFailure || result.Value is null || string.IsNullOrWhiteSpace(result.Value.Code))
 			return HttpServiceErrors.CreateErrorForStatusCode(response.StatusCode, response.ReasonPhrase);
 
 		return result.Value;

--- a/src/Facility.Core/Http/ServiceHttpHandler.cs
+++ b/src/Facility.Core/Http/ServiceHttpHandler.cs
@@ -75,7 +75,7 @@ public abstract class ServiceHttpHandler : DelegatingHandler
 			try
 			{
 				var serializer = GetHttpContentSerializer(mapping.RequestBodyType);
-				var requestResult = await AdaptTask(serializer.ReadHttpContentAsync(mapping.RequestBodyType, httpRequest.Content, cancellationToken)).ConfigureAwait(true);
+				var requestResult = await AdaptTask(serializer.ReadHttpContentOrNullAsync(mapping.RequestBodyType, httpRequest.Content, cancellationToken)).ConfigureAwait(true);
 				if (requestResult.IsFailure)
 					error = requestResult.Error;
 				else


### PR DESCRIPTION
This ensures backward compatibility with old clients when requests/responses transition between zero and non-zero field counts.