### PR TITLE
Bump MessagePack and System.Text.Json versions to address vulnerabilities.

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="Facility.Definition" Version="2.14.0" />
     <PackageVersion Include="Facility.CodeGen.Console" Version="2.14.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
-    <PackageVersion Include="MessagePack" Version="2.5.140" />
+    <PackageVersion Include="MessagePack" Version="2.5.192" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.3" />

--- a/src/Facility.Core/Facility.Core.csproj
+++ b/src/Facility.Core/Facility.Core.csproj
@@ -15,7 +15,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="System.Text.Json" VersionOverride="6.0.9" />
+    <PackageReference Include="System.Text.Json" VersionOverride="6.0.11" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Addresses:

```
error NU1903: Warning As Error: Package 'System.Text.Json' 6.0.9 has a known high severity vulnerability, https://github.com/advisories/GHSA-8g4q-xg66-9fp4
error NU1902: Warning As Error: Package 'MessagePack' 2.5.140 has a known moderate severity vulnerability, https://github.com/advisories/GHSA-4qm4-8hg2-g2xm
```