### PR TITLE
Allow tool to roll forward through major versions.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>2.29.4</VersionPrefix>
-    <PackageValidationBaselineVersion>2.29.3</PackageValidationBaselineVersion>
+    <VersionPrefix>2.30.0</VersionPrefix>
+    <PackageValidationBaselineVersion>2.29.4</PackageValidationBaselineVersion>
     <LangVersion>12.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,8 +6,8 @@
     <PackageVersion Include="ArgsReading" Version="2.3.2" />
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
     <PackageVersion Include="Facility.AspNetCore" Version="3.8.0" />
-    <PackageVersion Include="Facility.Definition" Version="2.14.0" />
-    <PackageVersion Include="Facility.CodeGen.Console" Version="2.14.0" />
+    <PackageVersion Include="Facility.Definition" Version="2.15.0" />
+    <PackageVersion Include="Facility.CodeGen.Console" Version="2.15.0" />
     <PackageVersion Include="FluentAssertions" Version="6.12.0" />
     <PackageVersion Include="MessagePack" Version="2.5.192" />
     <PackageVersion Include="Microsoft.CSharp" Version="4.7.0" />

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,5 +1,10 @@
 # Release Notes
 
+## 2.30.0
+
+* Drop support for end-of-life frameworks.
+* Use roll forward with .NET tools.
+
 ## 2.29.4
 
 * Bump `MessagePack` and `System.Text.Json` versions to address vulnerabilities.

--- a/src/Facility.CodeGen.CSharp/CSharpUtility.cs
+++ b/src/Facility.CodeGen.CSharp/CSharpUtility.cs
@@ -96,7 +96,7 @@ internal static class CSharpUtility
 		return builder.ToString();
 	}
 
-#if NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 	internal static bool ContainsOrdinal(this string text, char ch) => text.Contains(ch, StringComparison.Ordinal);
 #else
 	internal static bool ContainsOrdinal(this string text, char ch) => text.Contains(ch);

--- a/src/Facility.CodeGen.CSharp/Facility.CodeGen.CSharp.csproj
+++ b/src/Facility.CodeGen.CSharp/Facility.CodeGen.CSharp.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <Description>A library that generates C# for a Facility Service Definition.</Description>
     <PackageTags>Facility FSD C# CodeGen</PackageTags>
     <IsPackable>true</IsPackable>

--- a/src/Facility.Core.Assertions/Facility.Core.Assertions.csproj
+++ b/src/Facility.Core.Assertions/Facility.Core.Assertions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <Description>FluentAssertions extensions for Facility unit tests.</Description>
     <PackageTags>Facility FluentAssertions test testing</PackageTags>
     <IsPackable>true</IsPackable>

--- a/src/Facility.Core.MessagePack/Facility.Core.MessagePack.csproj
+++ b/src/Facility.Core.MessagePack/Facility.Core.MessagePack.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <Description>MesssagePack support for Facility.</Description>
     <PackageTags>Facility FSD MessagePack</PackageTags>
     <IsPackable>true</IsPackable>

--- a/src/Facility.Core/Facility.Core.csproj
+++ b/src/Facility.Core/Facility.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <Description>A library for consuming/implementing Facility APIs.</Description>
     <PackageTags>Facility FSD Core</PackageTags>
     <IsPackable>true</IsPackable>
@@ -14,8 +14,8 @@
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'netstandard2.1' ">
-    <PackageReference Include="System.Text.Json" VersionOverride="6.0.11" />
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Text.Json" VersionOverride="8.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Facility.Core/Http/BytesHttpContentSerializer.cs
+++ b/src/Facility.Core/Http/BytesHttpContentSerializer.cs
@@ -51,7 +51,7 @@ public class BytesHttpContentSerializer : HttpContentSerializer
 	{
 		if (objectType == typeof(byte[]))
 		{
-#if NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 			var contentValue = await content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
 #else
 			var contentValue = await content.ReadAsByteArrayAsync().ConfigureAwait(false);

--- a/src/Facility.Core/Http/HttpClientService.cs
+++ b/src/Facility.Core/Http/HttpClientService.cs
@@ -248,7 +248,7 @@ public abstract class HttpClientService
 		Stream? stream = null;
 		try
 		{
-#if NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 			stream = await httpResponse.Content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #else
 			stream = await httpResponse.Content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -329,7 +329,7 @@ public abstract class HttpClientService
 		}
 		finally
 		{
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 			if (stream is not null)
 				await stream.DisposeAsync().ConfigureAwait(false);
 #else
@@ -426,7 +426,7 @@ public abstract class HttpClientService
 				var bracketedKeyIndex = url.IndexOf(bracketedKey, StringComparison.Ordinal);
 				if (bracketedKeyIndex != -1)
 				{
-#if NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 					url = string.Concat(url.AsSpan(0, bracketedKeyIndex), Uri.EscapeDataString(parameter.Value), url.AsSpan(bracketedKeyIndex + bracketedKey.Length));
 #else
 					url = url.Substring(0, bracketedKeyIndex) + Uri.EscapeDataString(parameter.Value) + url.Substring(bracketedKeyIndex + bracketedKey.Length);

--- a/src/Facility.Core/Http/HttpContentSerializer.cs
+++ b/src/Facility.Core/Http/HttpContentSerializer.cs
@@ -91,7 +91,7 @@ public abstract class HttpContentSerializer
 
 				if (content.Headers.ContentLength is null)
 				{
-#if NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 					var contentValue = await content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
 #else
 					var contentValue = await content.ReadAsByteArrayAsync().ConfigureAwait(false);

--- a/src/Facility.Core/Http/JsonHttpContentSerializer.cs
+++ b/src/Facility.Core/Http/JsonHttpContentSerializer.cs
@@ -75,7 +75,7 @@ public class JsonHttpContentSerializer : HttpContentSerializer
 			{
 				// read content into memory so that ASP.NET Core doesn't complain about synchronous I/O during JSON deserialization
 				using var stream = CreateMemoryStream();
-#if NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 				await content.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
 #else
 				await content.CopyToAsync(stream).ConfigureAwait(false);
@@ -85,7 +85,7 @@ public class JsonHttpContentSerializer : HttpContentSerializer
 			}
 			else
 			{
-#if NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 				using var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
 #else
 				using var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);

--- a/src/Facility.Core/Http/ServiceHttpContext.cs
+++ b/src/Facility.Core/Http/ServiceHttpContext.cs
@@ -20,7 +20,7 @@ public sealed class ServiceHttpContext
 	/// </summary>
 	public static ServiceHttpContext? TryGetContext(HttpRequestMessage httpRequest)
 	{
-#if NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 		httpRequest.Options.TryGetValue(s_requestPropertyContextKey, out var context);
 		return context;
 #else
@@ -40,14 +40,14 @@ public sealed class ServiceHttpContext
 
 	internal static void SetContext(HttpRequestMessage httpRequest, ServiceHttpContext context)
 	{
-#if NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 		httpRequest.Options.Set(s_requestPropertyContextKey, context);
 #else
 		httpRequest.Properties[c_requestPropertyContextKey] = context;
 #endif
 	}
 
-#if NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 	private static readonly HttpRequestOptionsKey<ServiceHttpContext> s_requestPropertyContextKey = new("Facility_Context");
 #else
 	private const string c_requestPropertyContextKey = "Facility_Context";

--- a/src/Facility.Core/Http/ServiceHttpHandler.cs
+++ b/src/Facility.Core/Http/ServiceHttpHandler.cs
@@ -286,7 +286,7 @@ public abstract class ServiceHttpHandler : DelegatingHandler
 		protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
 			DoSerializeToStreamAsync(stream, CancellationToken.None);
 
-#if NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 		protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken) =>
 			DoSerializeToStreamAsync(stream, cancellationToken);
 #endif
@@ -321,20 +321,20 @@ public abstract class ServiceHttpHandler : DelegatingHandler
 
 				if (isError)
 				{
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 					await stream.WriteAsync(s_errorEventLine, cancellationToken).ConfigureAwait(false);
 #else
 					await stream.WriteAsync(s_errorEventLine.ToArray(), 0, s_errorEventLine.Length, cancellationToken).ConfigureAwait(false);
 #endif
 				}
 
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 				await stream.WriteAsync(s_dataPrefix, cancellationToken).ConfigureAwait(false);
 #else
 				await stream.WriteAsync(s_dataPrefix.ToArray(), 0, s_dataPrefix.Length, cancellationToken).ConfigureAwait(false);
 #endif
 
-#if NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 				using (var content = m_contentSerializer.CreateHttpContent(dto))
 					await content.CopyToAsync(stream, cancellationToken).ConfigureAwait(false);
 #else
@@ -342,7 +342,7 @@ public abstract class ServiceHttpHandler : DelegatingHandler
 					await content.CopyToAsync(stream).ConfigureAwait(false);
 #endif
 
-#if NETSTANDARD2_1_OR_GREATER || NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 				await stream.WriteAsync(s_twoNewlines, cancellationToken).ConfigureAwait(false);
 #else
 				await stream.WriteAsync(s_twoNewlines.ToArray(), 0, s_twoNewlines.Length, cancellationToken).ConfigureAwait(false);

--- a/src/Facility.Core/Http/StandardHttpContentSerializer.cs
+++ b/src/Facility.Core/Http/StandardHttpContentSerializer.cs
@@ -21,11 +21,8 @@ internal sealed class StandardHttpContentSerializer : HttpContentSerializer
 	{
 		try
 		{
-#if NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 			var stream = await content.ReadAsStreamAsync(cancellationToken).ConfigureAwait(false);
-			await using var streamScope = stream.ConfigureAwait(false);
-#elif NETSTANDARD2_1_OR_GREATER
-			var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
 			await using var streamScope = stream.ConfigureAwait(false);
 #else
 			using var stream = await content.ReadAsStreamAsync().ConfigureAwait(false);
@@ -54,7 +51,7 @@ internal sealed class StandardHttpContentSerializer : HttpContentSerializer
 		protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context) =>
 			DoSerializeToStreamAsync(stream, CancellationToken.None);
 
-#if NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 		protected override Task SerializeToStreamAsync(Stream stream, TransportContext? context, CancellationToken cancellationToken) =>
 			DoSerializeToStreamAsync(stream, cancellationToken);
 #endif

--- a/src/Facility.Core/Http/TextHttpContentSerializer.cs
+++ b/src/Facility.Core/Http/TextHttpContentSerializer.cs
@@ -52,7 +52,7 @@ public class TextHttpContentSerializer : HttpContentSerializer
 	{
 		if (objectType == typeof(string))
 		{
-#if NET6_0_OR_GREATER
+#if !NETSTANDARD2_0
 			var stringValue = await content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
 #else
 			var stringValue = await content.ReadAsStringAsync().ConfigureAwait(false);

--- a/src/FacilityConformance/FacilityConformance.csproj
+++ b/src/FacilityConformance/FacilityConformance.csproj
@@ -2,11 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>A tool that checks Facility conformance.</Description>
     <PackageTags>Facility conformance</PackageTags>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
+    <RollForward>Major</RollForward>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 

--- a/src/fsdgencsharp/fsdgencsharp.csproj
+++ b/src/fsdgencsharp/fsdgencsharp.csproj
@@ -2,11 +2,12 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>A tool that generates C# for a Facility Service Definition.</Description>
     <PackageTags>Facility FSD C# CodeGen</PackageTags>
     <IsPackable>true</IsPackable>
     <PackAsTool>true</PackAsTool>
+    <RollForward>Major</RollForward>
     <PackageReadmeFile>README.md</PackageReadmeFile>
   </PropertyGroup>
 


### PR DESCRIPTION
Drop end of life frameworks. Use NETSTANDARD2_0 as needed.