### PR TITLE
Fix IDE0370 warnings

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -31,4 +31,9 @@
     <DisablePackageBaselineValidation Condition=" $(PackageValidationBaselineVersion) == $(VersionPrefix) or $(PackageValidationBaselineVersion) == '0.0.0' ">true</DisablePackageBaselineValidation>
   </PropertyGroup>
 
+  <!-- Ignore "Suppression is unnecessary" warnings from TFMs lacking the latest nullability annotations -->
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net472' ">
+    <NoWarn>$(NoWarn);IDE0370</NoWarn>
+  </PropertyGroup>
+
 </Project>

--- a/src/Facility.CodeGen.CSharp/CSharpGenerator.cs
+++ b/src/Facility.CodeGen.CSharp/CSharpGenerator.cs
@@ -1787,7 +1787,7 @@ public sealed class CSharpGenerator : CodeGenerator
 			type.ValueType != null && NeedsValidation(type.ValueType!);
 
 		private static ServiceDtoInfo? TryGetDtoInfo(ServiceTypeInfo? type) =>
-			type is null ? null : type.Kind == ServiceTypeKind.Dto ? type.Dto! : TryGetDtoInfo(type.ValueType);
+			type is null ? null : type.Kind == ServiceTypeKind.Dto ? type.Dto : TryGetDtoInfo(type.ValueType);
 
 		private static HashSet<ServiceDtoInfo> FindDtosNeedingValidation(ServiceInfo service)
 		{

--- a/src/Facility.Core/ServiceNullableSystemTextJsonConverter.cs
+++ b/src/Facility.Core/ServiceNullableSystemTextJsonConverter.cs
@@ -38,7 +38,7 @@ public sealed class ServiceNullableSystemTextJsonConverter<T> : JsonConverter<Se
 	/// Reads the JSON representation of the object.
 	/// </summary>
 	public override ServiceNullable<T> Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options) =>
-		reader.TokenType is JsonTokenType.Null ? new ServiceNullable<T>(default!) : JsonSerializer.Deserialize<T>(ref reader, options)!;
+		reader.TokenType is JsonTokenType.Null ? new ServiceNullable<T>(default) : JsonSerializer.Deserialize<T>(ref reader, options);
 
 	/// <summary>
 	/// Writes the JSON representation of the object.
@@ -53,7 +53,7 @@ public sealed class ServiceNullableSystemTextJsonConverter<T> : JsonConverter<Se
 		}
 
 		if (value.Value is { } fieldValue)
-			JsonSerializer.Serialize<T>(writer, fieldValue, options);
+			JsonSerializer.Serialize(writer, fieldValue, options);
 		else
 			writer.WriteNullValue();
 	}

--- a/src/Facility.Core/ServiceResult.cs
+++ b/src/Facility.Core/ServiceResult.cs
@@ -69,7 +69,7 @@ public class ServiceResult
 	/// <summary>
 	/// The service result as a failure; null if it is a success.
 	/// </summary>
-	public ServiceResultFailure? AsFailure() => this as ServiceResultFailure ?? (IsFailure ? Failure(Error!) : null);
+	public ServiceResultFailure? AsFailure() => this as ServiceResultFailure ?? (IsFailure ? Failure(Error) : null);
 
 	/// <summary>
 	/// The service result as a failure; throws if it is a success.

--- a/tests/Facility.Core.UnitTests/ServiceResultTests.cs
+++ b/tests/Facility.Core.UnitTests/ServiceResultTests.cs
@@ -14,7 +14,7 @@ internal sealed class ServiceResultTests
 		var result = ServiceResult.Success();
 		result.IsSuccess.Should().BeTrue();
 		result.IsFailure.Should().BeFalse();
-		result.Error!.Should().BeNull();
+		result.Error.Should().BeNull();
 		result.Verify();
 		ServiceResultUtility.TryGetValue(result, out _).Should().BeFalse();
 	}
@@ -25,7 +25,7 @@ internal sealed class ServiceResultTests
 		var result = ServiceResult.Success(1);
 		result.IsSuccess.Should().BeTrue();
 		result.IsFailure.Should().BeFalse();
-		result.Error!.Should().BeNull();
+		result.Error.Should().BeNull();
 		result.Verify();
 		result.Value.Should().Be(1);
 		result.GetValueOrDefault().Should().Be(1);
@@ -39,7 +39,7 @@ internal sealed class ServiceResultTests
 		var result = ServiceResult.Success((string?) null);
 		result.IsSuccess.Should().BeTrue();
 		result.IsFailure.Should().BeFalse();
-		result.Error!.Should().BeNull();
+		result.Error.Should().BeNull();
 		result.Verify();
 		result.Value.Should().BeNull();
 		result.GetValueOrDefault().Should().BeNull();
@@ -59,7 +59,7 @@ internal sealed class ServiceResultTests
 		var result = ServiceResult.Failure(new ServiceErrorDto());
 		result.IsSuccess.Should().BeFalse();
 		result.IsFailure.Should().BeTrue();
-		result.Error!.Should().BeDto(new ServiceErrorDto());
+		result.Error.Should().BeDto(new ServiceErrorDto());
 		try
 		{
 			result.Verify();
@@ -78,7 +78,7 @@ internal sealed class ServiceResultTests
 		ServiceResult<int> result = ServiceResult.Failure(new ServiceErrorDto("Int32Failure"));
 		result.IsSuccess.Should().BeFalse();
 		result.IsFailure.Should().BeTrue();
-		result.Error!.Should().BeDto(new ServiceErrorDto("Int32Failure"));
+		result.Error.Should().BeDto(new ServiceErrorDto("Int32Failure"));
 		try
 		{
 			result.Verify();
@@ -104,11 +104,11 @@ internal sealed class ServiceResultTests
 	public void AlwaysCastFailure()
 	{
 		var failure = ServiceResult.Failure(new ServiceErrorDto("Failure"));
-		failure.Cast<int>().Error!.Should().BeDto(new ServiceErrorDto("Failure"));
+		failure.Cast<int>().Error.Should().BeDto(new ServiceErrorDto("Failure"));
 		ServiceResult noValue = ServiceResult.Failure(new ServiceErrorDto("NoValue"));
-		noValue.Cast<int>().Error!.Should().BeDto(new ServiceErrorDto("NoValue"));
+		noValue.Cast<int>().Error.Should().BeDto(new ServiceErrorDto("NoValue"));
 		ServiceResult<string> stringValue = ServiceResult.Failure(new ServiceErrorDto("StringValue"));
-		stringValue.Cast<int>().Error!.Should().BeDto(new ServiceErrorDto("StringValue"));
+		stringValue.Cast<int>().Error.Should().BeDto(new ServiceErrorDto("StringValue"));
 	}
 
 	[Test]
@@ -173,11 +173,11 @@ internal sealed class ServiceResultTests
 	{
 		var error = new ServiceErrorDto("Error");
 		var failure = ServiceResult.Failure(error);
-		failure.ToFailure().Error!.Should().BeDto(error);
+		failure.ToFailure().Error.Should().BeDto(error);
 		ServiceResult failedResult = ServiceResult.Failure(error);
-		failedResult.ToFailure().Error!.Should().BeDto(error);
+		failedResult.ToFailure().Error.Should().BeDto(error);
 		ServiceResult<int> failedValue = ServiceResult.Failure(error);
-		failedValue.ToFailure().Error!.Should().BeDto(error);
+		failedValue.ToFailure().Error.Should().BeDto(error);
 	}
 
 	[Test]


### PR DESCRIPTION
Run 'dotnet format' to automatically address unnecessary suppressions. Suppress the warning itself for netstandard2.0 and net472 as the nullability annotations for those TFMs are either old or irrelevant.