### PR TITLE
Include path template and http method in facility context.

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <VersionPrefix>2.38.0</VersionPrefix>
-    <PackageValidationBaselineVersion>2.37.0</PackageValidationBaselineVersion>
+    <VersionPrefix>2.39.0</VersionPrefix>
+    <PackageValidationBaselineVersion>2.38.0</PackageValidationBaselineVersion>
     <LangVersion>14.0</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>

--- a/src/Facility.Core/Http/ServiceHttpContext.cs
+++ b/src/Facility.Core/Http/ServiceHttpContext.cs
@@ -15,8 +15,19 @@ public sealed class ServiceHttpContext
 	/// </summary>
 	public ServiceResult<ServiceDto>? Result { get; internal set; }
 
+	/// <summary>
+	/// The path template for the route.
+	/// </summary>
 	public string? PathTemplate { get; internal set; }
 
+	/// <summary>
+	/// The base path for the API.
+	/// </summary>
+	public string? RootPath { get; internal set; }
+
+	/// <summary>
+	/// The HTTP method for the request.
+	/// </summary>
 	public HttpMethod? HttpMethod { get; internal set; }
 
 	/// <summary>

--- a/src/Facility.Core/Http/ServiceHttpContext.cs
+++ b/src/Facility.Core/Http/ServiceHttpContext.cs
@@ -15,6 +15,10 @@ public sealed class ServiceHttpContext
 	/// </summary>
 	public ServiceResult<ServiceDto>? Result { get; internal set; }
 
+	public string? PathTemplate { get; internal set; }
+
+	public HttpMethod? HttpMethod { get; internal set; }
+
 	/// <summary>
 	/// Attempts to get the context from the specified HTTP request.
 	/// </summary>

--- a/src/Facility.Core/Http/ServiceHttpHandler.cs
+++ b/src/Facility.Core/Http/ServiceHttpHandler.cs
@@ -105,6 +105,8 @@ public abstract partial class ServiceHttpHandler : DelegatingHandler
 			request = mapping.SetRequestHeaders(request, HttpServiceUtility.CreateDictionaryFromHeaders(httpRequest.Headers, httpRequest.Content?.Headers)!);
 
 			context.Request = request;
+			context.PathTemplate = m_rootPath + mapping.Path;
+			context.HttpMethod = mapping.HttpMethod;
 
 			if (!m_skipRequestValidation && !request.Validate(out var requestErrorMessage))
 				error = ServiceErrors.CreateInvalidRequest(requestErrorMessage);

--- a/src/Facility.Core/Http/ServiceHttpHandler.cs
+++ b/src/Facility.Core/Http/ServiceHttpHandler.cs
@@ -2,6 +2,7 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http.Headers;
+using System.Net.Mime;
 using System.Text.RegularExpressions;
 
 namespace Facility.Core.Http;
@@ -105,7 +106,8 @@ public abstract partial class ServiceHttpHandler : DelegatingHandler
 			request = mapping.SetRequestHeaders(request, HttpServiceUtility.CreateDictionaryFromHeaders(httpRequest.Headers, httpRequest.Content?.Headers)!);
 
 			context.Request = request;
-			context.PathTemplate = m_rootPath + mapping.Path;
+			context.PathTemplate = mapping.Path;
+			context.RootPath = m_rootPath;
 			context.HttpMethod = mapping.HttpMethod;
 
 			if (!m_skipRequestValidation && !request.Validate(out var requestErrorMessage))

--- a/src/Facility.Core/Http/ServiceHttpHandler.cs
+++ b/src/Facility.Core/Http/ServiceHttpHandler.cs
@@ -2,7 +2,6 @@ using System.Collections.Concurrent;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http.Headers;
-using System.Net.Mime;
 using System.Text.RegularExpressions;
 
 namespace Facility.Core.Http;


### PR DESCRIPTION
This will allow consumers to access the route template in order to normalize telemetry operation names in .NET.

See also https://github.com/FacilityApi/FacilityAspNet/pull/22