### PR TITLE
Store Facility route in current Activity using the 'http.route' tag

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -19,6 +19,7 @@
     <PackageVersion Include="Newtonsoft.Json" Version="13.0.4" />
     <PackageVersion Include="NUnit" Version="4.6.1" />
     <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageVersion Include="System.Diagnostics.DiagnosticSource" Version="10.0.9" />
     <PackageVersion Include="System.Net.ServerSentEvents" Version="10.0.9" />
     <PackageVersion Include="System.Text.Json" Version="10.0.9" />
   </ItemGroup>

--- a/src/Facility.Core/Facility.Core.csproj
+++ b/src/Facility.Core/Facility.Core.csproj
@@ -15,6 +15,10 @@
     <PackageReference Include="Newtonsoft.Json" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' ">
+    <PackageReference Include="System.Diagnostics.DiagnosticSource" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net8.0' or '$(TargetFramework)' == 'net9.0' ">
     <PackageReference Include="System.Net.ServerSentEvents" />
     <PackageReference Include="System.Text.Json" />

--- a/src/Facility.Core/Http/ServiceHttpHandler.cs
+++ b/src/Facility.Core/Http/ServiceHttpHandler.cs
@@ -1,4 +1,5 @@
 using System.Collections.Concurrent;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Net;
 using System.Net.Http.Headers;
@@ -61,10 +62,8 @@ public abstract partial class ServiceHttpHandler : DelegatingHandler
 		if (pathParameters == null)
 			return default;
 
-#if NETCOREAPP2_0_OR_GREATER
-		// for .NET targets, use Activity to pass the Facility route using the same tag as ASP.NET Core
-		System.Diagnostics.Activity.Current?.SetTag("http.route", m_rootPath + mapping.Path);
-#endif
+		// use Activity to pass the Facility route using the same tag as ASP.NET Core
+		Activity.Current?.SetTag("http.route", m_rootPath + mapping.Path);
 
 		var context = new ServiceHttpContext();
 		ServiceHttpContext.SetContext(httpRequest, context);

--- a/src/Facility.Core/Http/ServiceHttpHandler.cs
+++ b/src/Facility.Core/Http/ServiceHttpHandler.cs
@@ -61,6 +61,11 @@ public abstract partial class ServiceHttpHandler : DelegatingHandler
 		if (pathParameters == null)
 			return default;
 
+#if NETCOREAPP2_0_OR_GREATER
+		// for .NET targets, use Activity to pass the Facility route using the same tag as ASP.NET Core
+		System.Diagnostics.Activity.Current?.SetTag("http.route", mapping.Path);
+#endif
+
 		var context = new ServiceHttpContext();
 		ServiceHttpContext.SetContext(httpRequest, context);
 

--- a/src/Facility.Core/Http/ServiceHttpHandler.cs
+++ b/src/Facility.Core/Http/ServiceHttpHandler.cs
@@ -63,7 +63,7 @@ public abstract partial class ServiceHttpHandler : DelegatingHandler
 
 #if NETCOREAPP2_0_OR_GREATER
 		// for .NET targets, use Activity to pass the Facility route using the same tag as ASP.NET Core
-		System.Diagnostics.Activity.Current?.SetTag("http.route", mapping.Path);
+		System.Diagnostics.Activity.Current?.SetTag("http.route", m_rootPath + mapping.Path);
 #endif
 
 		var context = new ServiceHttpContext();


### PR DESCRIPTION
This allows any Activity-based telemetry pipeline (e.g., Azure Monitor) to report the original route with placeholders (e.g., "/users/{userId}/orders/{orderId}") to monitoring systems instead of the raw URL.

Replaces https://github.com/FacilityApi/FacilityCSharp/pull/115.